### PR TITLE
Update to 1.17.1 (and some smaller fixes)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.8.9'
+    id 'fabric-loom' version '0.8-SNAPSHOT'
 }
 
 sourceCompatibility = JavaVersion.VERSION_16
@@ -32,6 +32,10 @@ dependencies {
 
 processResources {
     inputs.property "version", project.version
+
+    filesMatching("fabric.mod.json") {
+        expand("version": project.version)
+    }
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,11 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
-# check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17
-yarn_mappings=1.17+build.9
-loader_version=0.11.3
+# check these on https://fabricmc.net/versions.html
+minecraft_version=1.17.1
+yarn_mappings=1.17.1+build.1
+loader_version=0.11.6
 # Mod Properties
 mod_version=1.2.4
 maven_group=net.devtech
 archives_base_name=trident_return
-

--- a/src/main/java/net/devtech/trident_return/mixin/ClientPlayNetworkHandlerMixin_ReturnToCorrectSlot.java
+++ b/src/main/java/net/devtech/trident_return/mixin/ClientPlayNetworkHandlerMixin_ReturnToCorrectSlot.java
@@ -30,7 +30,7 @@ public abstract class ClientPlayNetworkHandlerMixin_ReturnToCorrectSlot {
 	@Shadow public abstract void sendPacket(Packet<?> packet);
 
 	@Inject(method = "onScreenHandlerSlotUpdate",
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/PlayerScreenHandler;setStackInSlot(ILnet/minecraft/item/ItemStack;)V"))
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/PlayerScreenHandler;setStackInSlot(IILnet/minecraft/item/ItemStack;)V"))
 	public void onSetStack1(ScreenHandlerSlotUpdateS2CPacket packet, CallbackInfo ci) throws InterruptedException {
 		this.trident_return_send(packet);
 	}
@@ -49,6 +49,7 @@ public abstract class ClientPlayNetworkHandlerMixin_ReturnToCorrectSlot {
 				TridentReturnConfig.AntiCheatBypass bypass = TridentReturn.config.anticheatBypass;
 				if(bypass.enabled()) {
 					ClickSlotC2SPacket c2SPacket = new ClickSlotC2SPacket(packet.getSyncId(),
+					                                                      packet.getRevision(),
 					                                                      packet.getSlot(),
 					                                                      0,
 					                                                      SlotActionType.PICKUP,
@@ -62,6 +63,7 @@ public abstract class ClientPlayNetworkHandlerMixin_ReturnToCorrectSlot {
 					}
 
 					ClickSlotC2SPacket newPacket = new ClickSlotC2SPacket(packet.getSyncId(),
+					                                                      packet.getRevision(),
 					                                                      slotId,
 					                                                      0,
 					                                                      SlotActionType.PICKUP,
@@ -78,6 +80,7 @@ public abstract class ClientPlayNetworkHandlerMixin_ReturnToCorrectSlot {
 
 				} else {
 					ClickSlotC2SPacket c2SPacket = new ClickSlotC2SPacket(packet.getSyncId(),
+					                                                      packet.getRevision(),
 					                                                      packet.getSlot(),
 					                                                      destSlot,
 					                                                      SlotActionType.SWAP,

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,7 +9,7 @@
   ],
   "license": "LGPL-3.0",
   "icon": "assets/trident_return/icon.png",
-  "environment": "*",
+  "environment": "client",
   "mixins": [
     "trident_return.mixins.json"
   ],


### PR DESCRIPTION
- use recommended loom snapshot version
- update gradle.properties versions
- fix fabric.mod.json's `version` field not being expanded
- fix `ClientPlayNetworkHandlerMixin_ReturnToCorrectSlot` (new a new `revision` int was added)
- set mod as client only

Tested working!